### PR TITLE
feat: add status source setting with tmux/hybrid/jsonl modes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,10 +50,12 @@ const getSessionConfig = (): SessionConfig => {
   const config: SessionConfig = {
     sessionPattern: currentSettings.session.sessionPattern,
     maxSessionAgeHours: currentSettings.session.maxSessionAgeHours,
-    pollIntervalMs: currentSettings.session.pollIntervalMs
+    pollIntervalMs: currentSettings.session.pollIntervalMs,
+    statusSource: currentSettings.session.statusSource ?? "hybrid"
   }
 
   // Only add LLM config if provider is configured and not "none"
+  // LLM summaries work in both "hybrid" and "jsonl" modes
   if (currentSettings.llm.provider && currentSettings.llm.provider !== "none") {
     const llmConfig = toLlmConfig(currentSettings.llm)
     // Check if API key is required but missing

--- a/src/main/services/SettingsStore.ts
+++ b/src/main/services/SettingsStore.ts
@@ -24,6 +24,12 @@ const LlmProviderSchema = Schema.Union(
   Schema.Literal("lmstudio")
 )
 
+const StatusSourceSchema = Schema.Union(
+  Schema.Literal("tmux"),
+  Schema.Literal("jsonl"),
+  Schema.Literal("hybrid")
+)
+
 const LlmSettingsSchema = Schema.Struct({
   provider: LlmProviderSchema,
   model: Schema.String,
@@ -35,7 +41,8 @@ const SessionSettingsSchema = Schema.Struct({
   sessionPattern: Schema.String,
   maxSessionAgeHours: Schema.Number,
   pollIntervalMs: Schema.Number,
-  editorCommand: Schema.optional(Schema.String)
+  editorCommand: Schema.optional(Schema.String),
+  statusSource: Schema.optional(StatusSourceSchema)
 })
 
 const DisplaySettingsSchema = Schema.Struct({
@@ -78,6 +85,7 @@ const AppSettingsSchema = Schema.Struct({
 
 export type LlmSettings = typeof LlmSettingsSchema.Type
 export type SessionSettings = typeof SessionSettingsSchema.Type
+export type StatusSource = typeof StatusSourceSchema.Type
 export type DisplaySettings = typeof DisplaySettingsSchema.Type
 export type WindowSettings = typeof WindowSettingsSchema.Type
 export type UsageSettings = typeof UsageSettingsSchema.Type
@@ -96,7 +104,8 @@ export const DEFAULT_SESSION_SETTINGS: SessionSettings = {
   sessionPattern: ".*",
   maxSessionAgeHours: 48,
   pollIntervalMs: 60000, // 60 seconds (reduced LLM load)
-  editorCommand: "code"
+  editorCommand: "code",
+  statusSource: "hybrid" // hybrid: pane for status, JSONL for metadata on change
 }
 
 export const DEFAULT_DISPLAY_SETTINGS: DisplaySettings = {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,7 @@ export interface SessionSettings {
   maxSessionAgeHours: number
   pollIntervalMs: number
   editorCommand?: string
+  statusSource?: "tmux" | "jsonl" | "hybrid"
 }
 
 export interface DisplaySettings {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -313,7 +313,6 @@ export function App(): JSX.Element {
     const isHidden = hiddenSessions.has(session.name)
     const lruPosition = getLruPosition(session.name)
     const props = {
-      key: session.name,
       session,
       onFocus: handleFocusSession,
       onOpenEditor: handleOpenEditor,
@@ -322,9 +321,9 @@ export function App(): JSX.Element {
       lruPosition
     }
     return cardSize === "compact" ? (
-      <SessionRowCompact {...props} />
+      <SessionRowCompact key={session.name} {...props} />
     ) : (
-      <SessionRow {...props} />
+      <SessionRow key={session.name} {...props} />
     )
   }
 

--- a/src/renderer/components/SessionRow.tsx
+++ b/src/renderer/components/SessionRow.tsx
@@ -91,7 +91,9 @@ export function SessionRow({ session, onFocus, onOpenEditor, onToggleHide, isHid
   const modelStyle = getModelBadgeStyle(session.model)
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onKeyDown={handleKeyDown}
@@ -157,7 +159,7 @@ export function SessionRow({ session, onFocus, onOpenEditor, onToggleHide, isHid
           <span className="text-purple-400 text-[11px] font-medium">{session.gitBranch}</span>
         </div>
       )}
-    </button>
+    </div>
   )
 }
 
@@ -193,7 +195,9 @@ export function SessionRowCompact({ session, onFocus, onOpenEditor, onToggleHide
   const modelLetter = getModelLetter(session.model)
 
   return (
-    <button
+    <div
+      role="button"
+      tabIndex={0}
       onClick={handleClick}
       onDoubleClick={handleDoubleClick}
       onKeyDown={handleKeyDown}
@@ -244,7 +248,7 @@ export function SessionRowCompact({ session, onFocus, onOpenEditor, onToggleHide
           </button>
         )}
       </div>
-    </button>
+    </div>
   )
 }
 

--- a/src/renderer/components/Settings.tsx
+++ b/src/renderer/components/Settings.tsx
@@ -25,6 +25,8 @@ interface UsageSettings {
   resetMinute?: number
 }
 
+type StatusSource = "tmux" | "jsonl" | "hybrid"
+
 interface AppSettings {
   llm: LlmSettings
   session: {
@@ -32,6 +34,7 @@ interface AppSettings {
     maxSessionAgeHours: number
     pollIntervalMs: number
     editorCommand?: string
+    statusSource?: StatusSource
   }
   display?: DisplaySettings
   usage?: UsageSettings
@@ -175,6 +178,15 @@ export function Settings({ isOpen, onClose }: SettingsProps): JSX.Element | null
     setSettings({
       ...settings,
       session: newSession
+    })
+  }, [settings])
+
+  // Handle status source change
+  const handleStatusSourceChange = useCallback((statusSource: StatusSource) => {
+    if (!settings) return
+    setSettings({
+      ...settings,
+      session: { ...settings.session, statusSource }
     })
   }, [settings])
 
@@ -423,6 +435,76 @@ export function Settings({ isOpen, onClose }: SettingsProps): JSX.Element | null
                     )}
                   </div>
                 )}
+              </section>
+
+              {/* Status Detection Section */}
+              <section>
+                <h3 className="text-sm font-medium text-gray-300 mb-3">Status Detection</h3>
+
+                <div className="space-y-2">
+                  <label
+                    className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      (settings.session.statusSource ?? "hybrid") === "hybrid"
+                        ? "bg-blue-600/20 border-blue-500"
+                        : "bg-gray-700 border-gray-600 hover:bg-gray-600"
+                    }`}
+                    onClick={() => handleStatusSourceChange("hybrid")}
+                  >
+                    <input
+                      type="radio"
+                      name="statusSource"
+                      checked={(settings.session.statusSource ?? "hybrid") === "hybrid"}
+                      onChange={() => handleStatusSourceChange("hybrid")}
+                      className="mt-1"
+                    />
+                    <div>
+                      <div className="text-sm font-medium text-white">Hybrid (Recommended)</div>
+                      <div className="text-xs text-gray-400 mt-0.5">Pane for status, JSONL + LLM for summaries</div>
+                    </div>
+                  </label>
+
+                  <label
+                    className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      settings.session.statusSource === "tmux"
+                        ? "bg-blue-600/20 border-blue-500"
+                        : "bg-gray-700 border-gray-600 hover:bg-gray-600"
+                    }`}
+                    onClick={() => handleStatusSourceChange("tmux")}
+                  >
+                    <input
+                      type="radio"
+                      name="statusSource"
+                      checked={settings.session.statusSource === "tmux"}
+                      onChange={() => handleStatusSourceChange("tmux")}
+                      className="mt-1"
+                    />
+                    <div>
+                      <div className="text-sm font-medium text-white">Tmux Only</div>
+                      <div className="text-xs text-gray-400 mt-0.5">Status only, no metadata (fastest)</div>
+                    </div>
+                  </label>
+
+                  <label
+                    className={`flex items-start gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      settings.session.statusSource === "jsonl"
+                        ? "bg-blue-600/20 border-blue-500"
+                        : "bg-gray-700 border-gray-600 hover:bg-gray-600"
+                    }`}
+                    onClick={() => handleStatusSourceChange("jsonl")}
+                  >
+                    <input
+                      type="radio"
+                      name="statusSource"
+                      checked={settings.session.statusSource === "jsonl"}
+                      onChange={() => handleStatusSourceChange("jsonl")}
+                      className="mt-1"
+                    />
+                    <div>
+                      <div className="text-sm font-medium text-white">JSONL (Legacy)</div>
+                      <div className="text-xs text-gray-400 mt-0.5">Full parsing, enables LLM summaries</div>
+                    </div>
+                  </label>
+                </div>
               </section>
 
               {/* Session Matching Section */}


### PR DESCRIPTION
## Summary

Add configurable status detection modes to optimize CPU usage while maintaining feature parity.

### Status Detection Modes

| Mode | Status Source | JSONL Parsing | LLM Summaries |
|------|---------------|---------------|---------------|
| **Tmux Only** | Pane patterns | Never | No |
| **Hybrid** (default) | Pane patterns | Every poll | Yes (when configured) |
| **JSONL** | JSONL data | Every poll | Yes (when configured) |

### Changes

- Add `statusSource` setting with schema validation
- Add Status Detection section in Settings UI
- Refactor `SessionService.processSession()` for mode-based processing
- Enhance `TmuxService.detectPaneState()` with detailed bash command parsing (e.g., "approve: bash (commit)")
- Fix React warnings (key prop spread, button nesting)
- Add `lastTimestamp` field to `TrackedSession` for proper sorting
- Add time-based status enhancement for recent activity
- Enable LLM summaries in hybrid mode

## Known Issues / TODO

- [ ] LLM summaries not appearing in hybrid mode (debug logging added)
- [ ] Need to verify LLM analysis flow is being triggered correctly
- [ ] May need to investigate cache invalidation

## Test Plan

- [ ] Verify status indicators update in real-time for permission prompts
- [ ] Verify branch names and context % display correctly
- [ ] Verify LLM summaries work when configured
- [ ] Test switching between all three modes in Settings
- [ ] Confirm CPU usage reduction in tmux-only mode